### PR TITLE
Openmp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 SHELL=bash
-
+LDFLAGS="-L/usr/local/opt/llvm/lib"
 python:
-	CC=mpicc python setup.py build_ext --inplace
+	CC=mpicc LDFLAGS=$(LDFLAGS) python setup.py build_ext --inplace
 
 clean:
 	CC=mpicc python setup.py clean

--- a/setup.py
+++ b/setup.py
@@ -5,12 +5,13 @@ from distutils.extension import Extension
 from numpy import get_include
 
 Options.annotate = False
-compiler_directives = {"boundscheck": True, "cdivision": False}
-cflags = ["-Wno-unused-function", "-Wno-#warnings"]
+compiler_directives = {"boundscheck": False, "cdivision": True}
+cflags = ["-Wno-unused-function", "-Wno-#warnings", "-fopenmp"]
 
 extensions = [Extension(
     "*", ["skeletor/cython/*.pyx"],
     include_dirs=[get_include()], extra_compile_args=cflags,
+    extra_link_args=["-fopenmp"],
     depends=["picksc/ppic2/precision.h"])]
 
 setup(

--- a/skeletor/cython/deposit.pyx
+++ b/skeletor/cython/deposit.pyx
@@ -1,53 +1,81 @@
 from ctypes cimport real_t, real2_t, particle_t
+from cython.parallel import prange, parallel
+from libc.stdlib cimport abort, malloc, free
 
 def deposit(
         particle_t[:] particles, real_t[:,:] density, real2_t[:,:] J,
         real_t charge, int noff, int lbx, int lby, real_t S):
 
-    cdef int ix, iy
+    cdef int Np = particles.shape[0]
+    cdef int ip, ix, iy, k
     cdef real_t x, y
     cdef real_t dx, dy
     cdef real_t tx, ty
     cdef real_t vx, vy
+    cdef int nyp = density.shape[0]
+    cdef int nxp = density.shape[1]
+    cdef int size = nxp*nyp
 
-    for ip in range(particles.shape[0]):
+    with nogil, parallel():
+        # Deposition to local 1D arrays
+        den_local = <real_t *>malloc(size*sizeof(real_t))
+        Jx_local = <real_t *>malloc(size*sizeof(real_t))
+        Jy_local = <real_t *>malloc(size*sizeof(real_t))
 
-        x = particles[ip].x
-        y = particles[ip].y
+        for k in range(size):
+                den_local[k] = 0.0
+                Jx_local[k] = 0.0
+                Jy_local[k] = 0.0
 
-        # Calculate the fluctuating x-velocity
-        vx = particles[ip].vx + S*y
-        vy = particles[ip].vy
+        for ip in prange(Np, schedule='static'):
 
-        ix = <int> x
-        iy = <int> y
+            x = particles[ip].x
+            y = particles[ip].y
 
-        dx = x - <real_t> ix
-        dy = y - <real_t> iy
+            # Calculate the fluctuating x-velocity
+            vx = particles[ip].vx + S*y
+            vy = particles[ip].vy
 
-        tx = 1.0 - dx
-        ty = 1.0 - dy
+            ix = <int> x
+            iy = <int> y
 
-        iy -= noff
+            dx = x - <real_t> ix
+            dy = y - <real_t> iy
 
-        ix += lbx
-        iy += lby
+            tx = 1.0 - dx
+            ty = 1.0 - dy
 
-        density[iy  , ix  ] += ty*tx
-        density[iy  , ix+1] += ty*dx
-        density[iy+1, ix  ] += dy*tx
-        density[iy+1, ix+1] += dy*dx
+            iy = iy - noff
 
-        J[iy  , ix  ].x += ty*tx*vx
-        J[iy  , ix+1].x += ty*dx*vx
-        J[iy+1, ix  ].x += dy*tx*vx
-        J[iy+1, ix+1].x += dy*dx*vx
+            ix = ix + lbx
+            iy = iy + lby
 
-        J[iy  , ix  ].y += ty*tx*vy
-        J[iy  , ix+1].y += ty*dx*vy
-        J[iy+1, ix  ].y += dy*tx*vy
-        J[iy+1, ix+1].y += dy*dx*vy
+            # Store values in 1D arrays.
+            # We use that the position [iy, ix] in the matrix corresponds to
+            # the position [iy*nxp + ix] in the 1D arrays.
+            den_local[iy*nxp + ix] += ty*tx
+            den_local[iy*nxp + ix+1] += ty*dx
+            den_local[(iy+1)*nxp + ix] += dy*tx
+            den_local[(iy+1)*nxp + ix+1] += dy*dx
 
-    for iy in range(density.shape[0]):
-        for ix in range(density.shape[1]):
-            density[iy, ix] *= charge
+            Jx_local[iy*nxp + ix] += ty*tx*vx
+            Jx_local[iy*nxp + ix+1] += ty*dx*vx
+            Jx_local[(iy+1)*nxp + ix] += dy*tx*vx
+            Jx_local[(iy+1)*nxp + ix+1] += dy*dx*vx
+
+            Jy_local[iy*nxp + ix] += ty*tx*vy
+            Jy_local[iy*nxp + ix+1] += ty*dx*vy
+            Jy_local[(iy+1)*nxp + ix] += dy*tx*vy
+            Jy_local[(iy+1)*nxp + ix+1] += dy*dx*vy
+
+        # Add up contributions from each processor
+        with gil:
+            for ky in range(nyp):
+                for kx in range(nxp):
+                    density[ky, kx] += den_local[ky*nxp + kx]*charge
+                    J[ky, kx].x += Jx_local[ky*nxp + kx]
+                    J[ky, kx].y += Jy_local[ky*nxp + kx]
+            # Free memory
+            free(den_local)
+            free(Jx_local)
+            free(Jy_local)

--- a/skeletor/cython/deposit.pyx
+++ b/skeletor/cython/deposit.pyx
@@ -7,7 +7,7 @@ def deposit(
         real_t charge, int noff, int lbx, int lby, real_t S):
 
     cdef int Np = particles.shape[0]
-    cdef int ip, ix, iy, k
+    cdef int ip, ix, iy, k, ky, kx
     cdef real_t x, y
     cdef real_t dx, dy
     cdef real_t tx, ty

--- a/skeletor/cython/particle_boundary.pyx
+++ b/skeletor/cython/particle_boundary.pyx
@@ -1,16 +1,18 @@
 from ctypes cimport real_t, particle_t
+from cython.parallel import prange
 
 
 def periodic_x(particle_t[:] particles, int nx):
 
     cdef real_t Lx = <real_t> nx
+    cdef int ip
 
-    for ip in range(particles.shape[0]):
+    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
 
         while particles[ip].x < 0.0:
-            particles[ip].x += Lx
+            particles[ip].x = particles[ip].x + Lx
         while particles[ip].x >= Lx:
-            particles[ip].x -= Lx
+            particles[ip].x = particles[ip].x - Lx
 
 
 def calculate_ihole(particle_t[:] particles, int[:] ihole, real_t[:] edges):
@@ -41,13 +43,14 @@ def shear_periodic_y(particle_t[:] particles, int ny, real_t S, real_t t):
        used the values of y to update x and vx.
     """
     cdef real_t Ly = <real_t> ny
+    cdef int ip
 
-    for ip in range(particles.shape[0]):
+    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
         # Left
         if particles[ip].y < 0.0:
-            particles[ip].x -= S*Ly*t
-            particles[ip].vx -= S*Ly
+            particles[ip].x = particles[ip].x - S*Ly*t
+            particles[ip].vx = particles[ip].vx - S*Ly
         # Right
         if particles[ip].y >= Ly:
-            particles[ip].x += S*Ly*t
-            particles[ip].vx += S*Ly
+            particles[ip].x = particles[ip].x + S*Ly*t
+            particles[ip].vx = particles[ip].vx + S*Ly

--- a/skeletor/cython/particle_boundary.pyx
+++ b/skeletor/cython/particle_boundary.pyx
@@ -3,11 +3,11 @@ from cython.parallel import prange
 
 
 def periodic_x(particle_t[:] particles, int nx):
-
+    cdef int Np = particles.shape[0]
     cdef real_t Lx = <real_t> nx
     cdef int ip
 
-    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
+    for ip in prange(Np, nogil=True, schedule='static'):
 
         while particles[ip].x < 0.0:
             particles[ip].x = particles[ip].x + Lx
@@ -42,10 +42,11 @@ def shear_periodic_y(particle_t[:] particles, int ny, real_t S, real_t t):
        The periodic boundaries on y are handled by ppic2 *after* we have
        used the values of y to update x and vx.
     """
+    cdef int Np = particles.shape[0]
     cdef real_t Ly = <real_t> ny
     cdef int ip
 
-    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
+    for ip in prange(Np, nogil=True, schedule='static'):
         # Left
         if particles[ip].y < 0.0:
             particles[ip].x = particles[ip].x - S*Ly*t

--- a/skeletor/cython/particle_push.pyx
+++ b/skeletor/cython/particle_push.pyx
@@ -17,7 +17,7 @@ def boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
     cdef real_t tx, ty
 
     # Rescale magnetic field with qtmh = 0.5*dt*charge/mass
-    bz *= qtmh
+    bz = qtmh*bz
 
     for ip in prange(particles.shape[0], nogil=True, schedule='static'):
 
@@ -34,10 +34,10 @@ def boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
         tx = 1.0 - dx
         ty = 1.0 - dy
 
-        iy -= noff
+        iy = iy - noff
 
-        ix += lbx
-        iy += lby
+        ix = ix + lbx
+        iy = iy + lby
 
         ex = dy*(dx*E[iy+1, ix+1].x + tx*E[iy+1, ix].x)  \
             + ty*(dx*E[iy, ix+1].x + tx*E[iy, ix].x)
@@ -46,8 +46,8 @@ def boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
             + ty*(dx*E[iy, ix+1].y + tx*E[iy, ix].y)
 
         # Rescale electric field with qtmh = 0.5*dt*charge/mass
-        ex *= qtmh
-        ey *= qtmh
+        ex = qtmh*ex
+        ey = qtmh*ey
 
         vmx = particles[ip].vx + ex
         vmy = particles[ip].vy + ey
@@ -60,8 +60,8 @@ def boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
         particles[ip].vx = vmx + fac*vpy*bz + ex
         particles[ip].vy = vmy - fac*vpx*bz + ey
 
-        particles[ip].x += particles[ip].vx*dt
-        particles[ip].y += particles[ip].vy*dt
+        particles[ip].x = particles[ip].x + particles[ip].vx*dt
+        particles[ip].y = particles[ip].y + particles[ip].vy*dt
 
 
 def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
@@ -80,10 +80,10 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
     cdef real_t tx, ty
 
     # Rescale magnetic field with qtmh = 0.5*dt*charge/mass
-    bz *= qtmh
+    bz = qtmh*bz
 
     # Modify fields due to rotation and shear
-    bz += Omega*dt
+    bz = bz + Omega*dt
 
     for ip in prange(particles.shape[0], nogil=True, schedule='static'):
 
@@ -100,10 +100,10 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
         tx = 1.0 - dx
         ty = 1.0 - dy
 
-        iy -= noff
+        iy = iy - noff
 
-        ix += lbx
-        iy += lby
+        ix = ix + lbx
+        iy = iy + lby
 
         ex = dy*(dx*E[iy+1, ix+1].x + tx*E[iy+1, ix].x)  \
             + ty*(dx*E[iy, ix+1].x + tx*E[iy, ix].x)
@@ -112,11 +112,11 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
             + ty*(dx*E[iy, ix+1].y + tx*E[iy, ix].y)
 
         # Rescale electric & magnetic field with qtmh = 0.5*dt*charge/mass
-        ex *= qtmh
-        ey *= qtmh
+        ex = qtmh*ex
+        ey = qtmh*ey
 
         # Modify fields due to rotation and shear
-        ey -= S*y*bz
+        ey = ey - S*y*bz
 
         vmx = particles[ip].vx + ex
         vmy = particles[ip].vy + ey
@@ -129,8 +129,8 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
         particles[ip].vx = vmx + fac*vpy*bz + ex
         particles[ip].vy = vmy - fac*vpx*bz + ey
 
-        particles[ip].x += particles[ip].vx*dt
-        particles[ip].y += particles[ip].vy*dt
+        particles[ip].x = particles[ip].x + particles[ip].vx*dt
+        particles[ip].y = particles[ip].y + particles[ip].vy*dt
 
 
 def drift(particle_t[:] particles, real_t dt):

--- a/skeletor/cython/particle_push.pyx
+++ b/skeletor/cython/particle_push.pyx
@@ -1,4 +1,5 @@
 from ctypes cimport real_t, real2_t, particle_t
+from cython.parallel import prange
 
 
 def boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,

--- a/skeletor/cython/particle_push.pyx
+++ b/skeletor/cython/particle_push.pyx
@@ -5,8 +5,8 @@ from cython.parallel import prange
 def boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
                real_t qtmh, real_t dt, int noff, int lbx, int lby):
 
+    cdef int Np = particles.shape[0]
     cdef real_t ex, ey
-
     cdef real_t vmx, vmy
     cdef real_t vpx, vpy
     cdef real_t fac
@@ -20,7 +20,7 @@ def boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
     # Rescale magnetic field with qtmh = 0.5*dt*charge/mass
     bz = qtmh*bz
 
-    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
+    for ip in prange(Np, nogil=True, schedule='static'):
 
         # Interpolate field onto particle (TODO: Move to separate function)
         x = particles[ip].x
@@ -69,8 +69,8 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
                         real_t qtmh, real_t dt, int noff, int lbx, int lby,
                         real_t Omega, real_t S):
 
+    cdef int Np = particles.shape[0]
     cdef real_t ex, ey
-
     cdef real_t vmx, vmy
     cdef real_t vpx, vpy
     cdef real_t fac
@@ -86,7 +86,7 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
     # Modify fields due to rotation and shear
     bz = bz + Omega*dt
 
-    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
+    for ip in prange(Np, nogil=True, schedule='static'):
 
         # Interpolate field onto particle (TODO: Move to separate function)
         x = particles[ip].x
@@ -136,8 +136,9 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
 
 def drift(particle_t[:] particles, real_t dt):
 
+    cdef int Np = particles.shape[0]
     cdef int ip
-    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
+    for ip in prange(Np, nogil=True, schedule='static'):
 
-        particles[ip].x += particles[ip].vx*dt
-        particles[ip].y += particles[ip].vy*dt
+        particles[ip].x = particles[ip].x + particles[ip].vx*dt
+        particles[ip].y = particles[ip].y + particles[ip].vy*dt

--- a/skeletor/cython/particle_push.pyx
+++ b/skeletor/cython/particle_push.pyx
@@ -11,7 +11,8 @@ def boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
     cdef real_t vpx, vpy
     cdef real_t fac
 
-    cdef int ix, iy
+    # It might be better to use `Py_ssize_t` instead of `int`
+    cdef int ip, ix, iy
     cdef real_t x, y
     cdef real_t dx, dy
     cdef real_t tx, ty
@@ -74,7 +75,7 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
     cdef real_t vpx, vpy
     cdef real_t fac
 
-    cdef int ix, iy
+    cdef int ip, ix, iy
     cdef real_t x, y
     cdef real_t dx, dy
     cdef real_t tx, ty
@@ -135,6 +136,7 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
 
 def drift(particle_t[:] particles, real_t dt):
 
+    cdef int ip
     for ip in prange(particles.shape[0], nogil=True, schedule='static'):
 
         particles[ip].x += particles[ip].vx*dt

--- a/skeletor/cython/particle_push.pyx
+++ b/skeletor/cython/particle_push.pyx
@@ -18,7 +18,7 @@ def boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
     # Rescale magnetic field with qtmh = 0.5*dt*charge/mass
     bz *= qtmh
 
-    for ip in range(particles.shape[0]):
+    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
 
         # Interpolate field onto particle (TODO: Move to separate function)
         x = particles[ip].x
@@ -84,7 +84,7 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
     # Modify fields due to rotation and shear
     bz += Omega*dt
 
-    for ip in range(particles.shape[0]):
+    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
 
         # Interpolate field onto particle (TODO: Move to separate function)
         x = particles[ip].x
@@ -134,7 +134,7 @@ def modified_boris_push(particle_t[:] particles, real2_t[:, :] E, real_t bz,
 
 def drift(particle_t[:] particles, real_t dt):
 
-    for ip in range(particles.shape[0]):
+    for ip in prange(particles.shape[0], nogil=True, schedule='static'):
 
         particles[ip].x += particles[ip].vx*dt
         particles[ip].y += particles[ip].vy*dt


### PR DESCRIPTION
I have started using cProfile to look at the speedup of various functions. The command is
```
make OMPI_CC=gcc-6
export OMP_NUM_THREADS=1
python -O -m cProfile -s time example/landau_ions.py
```

I have also used the guide found [here](https://itsharveytime.com/2014/06/03/using-cprofile-with-python/). Simply do the following:

```
python -O -m cProfile -o output.profile example/landau_ions.py
python -m pstats output.profile
sort time
stats 8
```
## One thread
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      192    9.285    0.048    9.285    0.048 {skeletor.cython.particle_push.boris_push}
      193    6.814    0.035    6.814    0.035 {skeletor.cython.deposit.deposit}
      192    1.269    0.007    1.269    0.007 {skeletor.cython.particle_boundary.calculate_ihole}
      192    1.248    0.007    1.248    0.007 {skeletor.cython.particle_boundary.periodic_x}
    80/32    0.267    0.003    0.465    0.015 {built-in method _imp.create_dynamic}
        2    0.177    0.088    0.177    0.088 {method 'normal' of 'mtrand.RandomState' objects}
        1    0.093    0.093    0.093    0.093 landau_ions.py:62(ux_an)
        1    0.086    0.086    0.089    0.089 particles.py:62(initialize)
```
## Two threads
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      192    4.788    0.025    4.788    0.025 {skeletor.cython.particle_push.boris_push}
      193    3.273    0.017    3.273    0.017 {skeletor.cython.deposit.deposit}
      192    1.156    0.006    1.156    0.006 {skeletor.cython.particle_boundary.calculate_ihole}
      192    0.727    0.004    0.727    0.004 {skeletor.cython.particle_boundary.periodic_x}
    80/32    0.258    0.003    0.443    0.014 {built-in method _imp.create_dynamic}
        2    0.178    0.089    0.178    0.089 {method 'normal' of 'mtrand.RandomState' objects}
        1    0.095    0.095    0.095    0.095 example/landau_ions.py:62(ux_an)
        1    0.087    0.087    0.087    0.087 example/landau_ions.py:66(uy_an)
```

## Four threads
```
   ncalls  tottime  percall  cumtime  percall filename:lineno(function)
      192    3.573    0.019    3.573    0.019 {skeletor.cython.particle_push.boris_push}
      193    2.296    0.012    2.296    0.012 {skeletor.cython.deposit.deposit}
      192    1.253    0.007    1.253    0.007 {skeletor.cython.particle_boundary.calculate_ihole}
      192    0.656    0.003    0.656    0.003 {skeletor.cython.particle_boundary.periodic_x}
    80/32    0.262    0.003    0.471    0.015 {built-in method _imp.create_dynamic}
        2    0.178    0.089    0.178    0.089 {method 'normal' of 'mtrand.RandomState' objects}
        1    0.092    0.092    0.092    0.092 example/landau_ions.py:62(ux_an)
        1    0.085    0.085    0.088    0.088 /Users/berlok/codes/skeletor/skeletor/particles.py:62(initialize)
```