### PR TITLE
Added `__array_finalize__()` method to ShearField

### DIFF
--- a/skeletor/field.py
+++ b/skeletor/field.py
@@ -145,6 +145,16 @@ class ShearField(Field):
 
         return obj
 
+    def __array_finalize__(self, obj):
+
+        super().__array_finalize__(obj)
+
+        if obj is None:
+            return
+
+        self.kx = getattr(obj, "kx", None)
+        self.y_kx = getattr(obj, "y_kx", None)
+
     def _translate_boundary(self, trans, iy):
 
         "Translation using FFTs"


### PR DESCRIPTION
The reason why this is needed is the following. Suppose `J` is a
3-vector ShearField. As such it has the "azimuthal" wavenumber `kx` as
attribute, which is defined in `ShearField.__new__()`. Now, The way
indexing of structured arrays in Numpy works, `J['x']` is a scalar
ShearField. It has a different dtype than `J` but it is nevertheless a
ShearField. One would therefore expect `J['x']` to also have the attribute
`kx`. `ShearField.__array_finalize__` makes sure that it indeed does.