### PR TITLE
particles['x'] and ['y'] now always in grid units

### DIFF
--- a/skeletor/initial_condition.py
+++ b/skeletor/initial_condition.py
@@ -37,8 +37,8 @@ class InitialCondition():
                 manifold.Ly/manifold.comm.size*uniform(size=np)
 
         # Set initial position
-        ions['x'][:np] = x
-        ions['y'][:np] = y
+        ions['x'][:np] = x/manifold.dx
+        ions['y'][:np] = y/manifold.dy
 
         # Draw particle velocities from a normal distribution
         # with zero mean and width 'vt'
@@ -116,8 +116,8 @@ class DensityPertubation(InitialCondition):
             y[k*npx:(k+1)*npx] = Uy[k]
 
         # Set initial positions
-        ions['x'][:np] = x
-        ions['y'][:np] = y
+        ions['x'][:np] = x/manifold.dx
+        ions['y'][:np] = y/manifold.dy
 
         # Draw particle velocities from a normal distribution
         # with zero mean and width 'vt'

--- a/skeletor/particles.py
+++ b/skeletor/particles.py
@@ -64,10 +64,8 @@ class Particles(numpy.ndarray):
         from numpy import logical_and, sum
         from warnings import warn
 
-        dy = self.manifold.dy
-
-        ind = logical_and(y >= self.manifold.edges[0]*dy,
-                          y < self.manifold.edges[1]*dy)
+        ind = logical_and(y >= self.manifold.edges[0]*self.manifold.dy,
+                          y < self.manifold.edges[1]*self.manifold.dy)
 
         # Number of particles in subdomain
         self.np = sum(ind)
@@ -79,16 +77,13 @@ class Particles(numpy.ndarray):
             warn(msg + " (np={}, npmax={})".format(self.np, self.size))
 
         # Fill structured array
-        self["x"][:self.np] = x[ind]
-        self["y"][:self.np] = y[ind]
+        self["x"][:self.np] = x[ind]/self.manifold.dx
+        self["y"][:self.np] = y[ind]/self.manifold.dy
         self["vx"][:self.np] = vx[ind]
         self["vy"][:self.np] = vy[ind]
         self["vz"][:self.np] = vz[ind]
 
         self.units = True
-
-        # Convert positions to be measured in grid spacings
-        self.from_units()
 
     def move(self):
         """Uses ppic2's cppmove2 routine for moving particles
@@ -229,24 +224,3 @@ class Particles(numpy.ndarray):
         # Apply periodicity in x and y
         self.periodic_x()
         self.periodic_y()
-
-    def to_units(self):
-        """Convert particle positions to be the position in the simulation"""
-
-        assert not self.units, "Attempting to convert units twice!"
-
-        self["x"][:self.np] *= self.manifold.dx
-        self["y"][:self.np] *= self.manifold.dy
-
-        self.units = True
-
-    def from_units(self):
-        """Convert particle positions to be measured in grid
-        spacing coordinates"""
-
-        assert self.units, "Attempting to convert units twice!"
-
-        self["x"][:self.np] /= self.manifold.dx
-        self["y"][:self.np] /= self.manifold.dy
-
-        self.units = False

--- a/tests/test_circular.py
+++ b/tests/test_circular.py
@@ -140,12 +140,14 @@ def test_circular(plot=False):
     init = InitialCondition(npc, quiet=quiet)
     init(manifold, ions)
 
-    # Perturbation to particle velocities
-    ions['vx'] = Ux_an(ions['x'], ions['y'], t=-dt/2)
-    ions['vy'] = Uy_an(ions['x'], ions['y'], t=-dt/2)
-    ions['vz'] = Uz_an(ions['x'], ions['y'], t=-dt/2)
+    # Particle position in physical units
+    x = ions['x']*manifold.dx
+    y = ions['y']*manifold.dy
 
-    ions.from_units()
+    # Perturbation to particle velocities
+    ions['vx'] = Ux_an(x, y, t=-dt/2)
+    ions['vy'] = Uy_an(x, y, t=-dt/2)
+    ions['vz'] = Uz_an(x, y, t=-dt/2)
 
     def B_an(t):
         B_an = Field(manifold, dtype=Float3)

--- a/tests/test_fastwave.py
+++ b/tests/test_fastwave.py
@@ -99,12 +99,14 @@ def test_fastwave(plot=False):
     init = InitialCondition(npc, quiet=quiet)
     init(manifold, ions)
 
-    # Perturbation to particle velocities
-    ions['vx'] = ux_an(ions['x'], ions['y'], t=0)
-    ions['vy'] = uy_an(ions['x'], ions['y'], t=0)
-    ions['vz'] = uz_an(ions['x'], ions['y'], t=0)
+    # Particle position in physical units
+    x = ions['x']*manifold.dx
+    y = ions['y']*manifold.dy
 
-    ions.from_units()
+    # Perturbation to particle velocities
+    ions['vx'] = ux_an(x, y, t=0)
+    ions['vy'] = uy_an(x, y, t=0)
+    ions['vz'] = uz_an(x, y, t=0)
 
     # Make sure the numbers of particles in each subdomain add up to the
     # total number of particles


### PR DESCRIPTION
I think it's best (least confusing) for the coordinates in the particle
array not to measured in different units in different parts of the code.