### PR TITLE
`Field.trim()` now squeezes the array

### DIFF
--- a/skeletor/field.py
+++ b/skeletor/field.py
@@ -47,10 +47,6 @@ class Field(np.ndarray):
         return self.grid.comm.sendrecv(
                 sendbuf, dest=self.below, source=self.above)
 
-    def trim(self):
-        return np.asarray(self[self.grid.lby:self.grid.uby,
-                               self.grid.lbx:self.grid.ubx])
-
     @property
     def active(self):
         return np.asarray(self[self.grid.lby:self.grid.uby,
@@ -60,6 +56,9 @@ class Field(np.ndarray):
     def active(self, rhs):
         self[self.grid.lby:self.grid.uby,
              self.grid.lbx:self.grid.ubx] = rhs
+
+    def trim(self):
+        return self.active.squeeze()
 
     def copy_guards(self):
         "Copy data to guard cells from corresponding active cells."


### PR DESCRIPTION
This means that if nx=32 and ny=1, say, and A is an instance of the
Field class, then A.trim() returns an array with shape (32,) instead of
(1, 32).